### PR TITLE
Adding Cluster Events to API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>2.0.6-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Edmunds.com, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 package com.edmunds.rest.databricks.DTO;
 
 import java.io.Serializable;
@@ -22,22 +6,23 @@ import java.io.Serializable;
  *
  */
 public enum ClusterEventTypeDTO implements Serializable {
-  CREATING("CREATING"),
-  STARTING("STARTING"),
-  RESTARTING("RESTARTING"),
-  TERMINATING("TERMINATING"),
-  EDITED("EDITED"),
-  RUNNING("RUNNING"),
-  RESIZING("RESIZING"),
-  NODES_LOST("NODES_LOST");
+    CREATING("CREATING"),
+    STARTING("STARTING"),
+    RESTARTING("RESTARTING"),
+    TERMINATING("TERMINATING"),
+    EDITED("EDITED"),
+    RUNNING("RUNNING"),
+    RESIZING("RESIZING"),
+    UPSIZE_COMPLETED("UPSIZE_COMPLETED"),
+    NODES_LOST("NODES_LOST");
 
-  private String value;
+    private String value;
 
-  ClusterEventTypeDTO(String value) {
-    this.value = value;
-  }
+    ClusterEventTypeDTO(String value) {
+        this.value = value;
+    }
 
-  public String toString() {
-    return this.value;
-  }
+    public String toString() {
+        return this.value;
+    }
 }

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Edmunds.com, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package com.edmunds.rest.databricks.DTO;
 
 import java.io.Serializable;

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventTypeDTO.java
@@ -19,10 +19,16 @@ package com.edmunds.rest.databricks.DTO;
 import java.io.Serializable;
 
 /**
- *
+ * Cluster Event DTO object. See below link.
+ * @see <a href="https://docs.databricks.com/api/latest/clusters.html#clustereventsclustereventtype">https://docs.databricks.com/api/latest/clusters.html#clustereventsclustereventtype</a>
  */
 public enum ClusterEventTypeDTO implements Serializable {
     CREATING("CREATING"),
+    DID_NOT_EXPAND_DISK("DID_NOT_EXPAND_DISK"),
+    EXPANDED_DISK("EXPANDED_DISK"),
+    FAILED_TO_EXPAND_DISK("FAILED_TO_EXPAND_DISK"),
+    INIT_SCRIPTS_STARTING("INIT_SCRIPTS_STARTING"),
+    INIT_SCRIPTS_FINISHED("INIT_SCRIPTS_FINISHED"),
     STARTING("STARTING"),
     RESTARTING("RESTARTING"),
     TERMINATING("TERMINATING"),

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
@@ -1,0 +1,17 @@
+package com.edmunds.rest.databricks.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class ClusterEventsDTO {
+    @JsonProperty("events")
+    private List<ClusterEventDTO> events;
+
+    public List<ClusterEventDTO> getEvents() {
+        return events;
+    }
+
+    public void setEvents(List<ClusterEventDTO> events) {
+        this.events = events;
+    }
+}

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class ClusterEventsDTO {
-    @JsonProperty("events")
+
     private List<ClusterEventDTO> events;
 
     public List<ClusterEventDTO> getEvents() {

--- a/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/ClusterEventsDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Edmunds.com, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package com.edmunds.rest.databricks.DTO;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -17,6 +17,8 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
@@ -115,4 +117,7 @@ public interface ClusterService {
    */
   ClusterInfoDTO[] list() throws IOException, DatabricksRestException;
 
+
+  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int limit) throws IOException,
+      DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -117,7 +117,14 @@ public interface ClusterService {
    */
   ClusterInfoDTO[] list() throws IOException, DatabricksRestException;
 
-
-  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int limit) throws IOException,
+  /**
+   * Lists events of a specific cluster on a given databricks instance.
+   * Allows you to filter which events you want to see too.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#events">https://docs.databricks.com/api/latest/clusters.html#events</a>
+   * @return an array of cluster information objects
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int offset, int limit) throws IOException,
       DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -121,10 +121,11 @@ public interface ClusterService {
    * Lists events of a specific cluster on a given databricks instance.
    * Allows you to filter which events you want to see too.
    * @see <a href="https://docs.databricks.com/api/latest/clusters.html#events">https://docs.databricks.com/api/latest/clusters.html#events</a>
-   * @return an array of cluster information objects
+   * @return an array of cluster events objects
    * @throws IOException any other errors
    * @throws DatabricksRestException any errors with the request
    */
-  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int offset, int limit) throws IOException,
+  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
+      int offset, int limit) throws IOException,
       DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -17,6 +17,7 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
@@ -24,6 +25,7 @@ import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
 import com.edmunds.rest.databricks.request.EditClusterRequest;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * A Wrapper around the cluster part of the databricks rest api.
@@ -125,7 +127,7 @@ public interface ClusterService {
    * @throws IOException any other errors
    * @throws DatabricksRestException any errors with the request
    */
-  ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
+  List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
       int offset, int limit) throws IOException,
       DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -17,6 +17,7 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
@@ -28,6 +29,7 @@ import com.edmunds.rest.databricks.restclient.DatabricksRestClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -110,7 +112,7 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
   }
 
   @Override
-  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
+  public List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
       int offset, int limit) throws
       IOException,
       DatabricksRestException {
@@ -120,6 +122,7 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
     data.put("offset", offset);
     data.put("limit", limit);
     byte[] responseBody = client.performQuery(RequestMethod.POST, "/clusters/events", data);
-    return this.mapper.readValue(responseBody, ClusterEventsDTO.class);
+    ClusterEventsDTO clusterEvents = this.mapper.readValue(responseBody, ClusterEventsDTO.class);
+    return clusterEvents.getEvents();
   }
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -17,6 +17,8 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.RequestMethod;
@@ -105,5 +107,18 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
         .readValue(responseBody, new TypeReference<Map<String, ClusterInfoDTO[]>>() {
         });
     return jsonObject.get("clusters");
+  }
+
+  // TODO this needs to properly handle offsets and limits!!
+  @Override
+  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int limit) throws
+      IOException,
+      DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("cluster_id", clusterId);
+    data.put("event_types", eventsToFilter);
+    data.put("limit", limit);
+    byte[] responseBody = client.performQuery(RequestMethod.POST, "/clusters/events", data);
+    return this.mapper.readValue(responseBody, ClusterEventsDTO.class);
   }
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -109,14 +109,14 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
     return jsonObject.get("clusters");
   }
 
-  // TODO this needs to properly handle offsets and limits!!
   @Override
-  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int limit) throws
+  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int offset, int limit) throws
       IOException,
       DatabricksRestException {
     Map<String, Object> data = new HashMap<>();
     data.put("cluster_id", clusterId);
     data.put("event_types", eventsToFilter);
+    data.put("offset", offset);
     data.put("limit", limit);
     byte[] responseBody = client.performQuery(RequestMethod.POST, "/clusters/events", data);
     return this.mapper.readValue(responseBody, ClusterEventsDTO.class);

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -110,7 +110,8 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
   }
 
   @Override
-  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter, int offset, int limit) throws
+  public ClusterEventsDTO listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
+      int offset, int limit) throws
       IOException,
       DatabricksRestException {
     Map<String, Object> data = new HashMap<>();

--- a/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
@@ -206,6 +206,8 @@ public class JobServiceImpl extends DatabricksService implements JobService {
     }
     if (activeOnly != null) {
       data.put("active_only", activeOnly);
+    } else {
+      data.put("completed_only", true);
     }
     if (offset != null) {
       data.put("offset", offset);

--- a/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
@@ -206,9 +206,8 @@ public class JobServiceImpl extends DatabricksService implements JobService {
     }
     if (activeOnly != null) {
       data.put("active_only", activeOnly);
-    } else {
-      data.put("completed_only", true);
     }
+    //TODO we need a way to do completed_only
     if (offset != null) {
       data.put("offset", offset);
     }

--- a/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
@@ -165,7 +165,7 @@ public class ClusterServiceTest {
   public void listEvents_whenCalled_showsEvents() throws IOException, DatabricksRestException {
     ClusterInfoDTO[] clusterInfoDTO = service.list();
     String clusterId = clusterInfoDTO[0].getClusterId();
-    ClusterEventsDTO events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 50);
+    ClusterEventsDTO events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50);
     assert(events.getEvents().size() > 0);
   }
 }

--- a/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
@@ -17,6 +17,7 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
@@ -26,6 +27,7 @@ import com.edmunds.rest.databricks.DatabricksServiceFactory;
 import com.edmunds.rest.databricks.fixtures.DatabricksFixtures;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
 import com.edmunds.rest.databricks.request.EditClusterRequest;
+import java.util.List;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,10 +50,6 @@ public class ClusterServiceTest {
 
   @BeforeClass
   public void setUpOnce() throws IOException, DatabricksRestException {
-    if (true) {
-      throw new SkipException("Running these tests takes time and costs money");
-    }
-
     DatabricksServiceFactory factory = DatabricksFixtures.getDatabricksServiceFactory();
     service = factory.getClusterService();
     String uniqueId = UUID.randomUUID().toString();
@@ -165,7 +163,7 @@ public class ClusterServiceTest {
   public void listEvents_whenCalled_showsEvents() throws IOException, DatabricksRestException {
     ClusterInfoDTO[] clusterInfoDTO = service.list();
     String clusterId = clusterInfoDTO[0].getClusterId();
-    ClusterEventsDTO events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50);
-    assert(events.getEvents().size() > 0);
+    List<ClusterEventDTO> events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50);
+    assertTrue(events.size() > 0);
   }
 }

--- a/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
@@ -17,6 +17,8 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.AutoScaleDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventTypeDTO;
+import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
 import com.edmunds.rest.databricks.DTO.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DTO.ClusterStateDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
@@ -157,5 +159,13 @@ public class ClusterServiceTest {
     ClusterInfoDTO clusterInfo = service.getInfo(clusterId);
     assertEquals(clusterInfo.getNodeTypeId(), "r3.2xlarge");
     assertEquals(clusterInfo.getNumWorkers(), 1);
+  }
+
+  @Test
+  public void listEvents_whenCalled_showsEvents() throws IOException, DatabricksRestException {
+    ClusterInfoDTO[] clusterInfoDTO = service.list();
+    String clusterId = clusterInfoDTO[0].getClusterId();
+    ClusterEventsDTO events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 50);
+    assert(events.getEvents().size() > 0);
   }
 }


### PR DESCRIPTION
Currently this functionality is used by automated pricing report to determine roughly how many nodes were up over the course of a cluster lifespan.