### PR TITLE
Issue 26/add groups api

### DIFF
--- a/src/main/java/com/edmunds/rest/databricks/DTO/PrincipalNameDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/PrincipalNameDTO.java
@@ -1,0 +1,19 @@
+package com.edmunds.rest.databricks.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+/**
+ *
+ */
+@Data
+public class PrincipalNameDTO implements Serializable {
+    @Getter @Setter @JsonProperty("user_name")
+    private String userName;
+    @Getter @Setter @JsonProperty("group_name")
+    private String groupName;
+}

--- a/src/main/java/com/edmunds/rest/databricks/DatabricksServiceFactory.java
+++ b/src/main/java/com/edmunds/rest/databricks/DatabricksServiceFactory.java
@@ -23,6 +23,8 @@ import com.edmunds.rest.databricks.service.ClusterService;
 import com.edmunds.rest.databricks.service.ClusterServiceImpl;
 import com.edmunds.rest.databricks.service.DbfsService;
 import com.edmunds.rest.databricks.service.DbfsServiceImpl;
+import com.edmunds.rest.databricks.service.GroupsService;
+import com.edmunds.rest.databricks.service.GroupsServiceImpl;
 import com.edmunds.rest.databricks.service.JobService;
 import com.edmunds.rest.databricks.service.JobServiceImpl;
 import com.edmunds.rest.databricks.service.LibraryService;
@@ -59,6 +61,7 @@ public class DatabricksServiceFactory {
   private WorkspaceService workspaceService;
   private JobService jobService;
   private DbfsService dbfsService;
+  private GroupsService groupsService;
 
   public DatabricksServiceFactory(DatabricksRestClient databricksRestClient) {
     this.client2dot0 = databricksRestClient;
@@ -66,9 +69,8 @@ public class DatabricksServiceFactory {
 
   /**
    * Old constructor.
-   * @deprecated in version 2.0.2,
-   *     please use {@link Builder#createUserPasswordAuthentication(String,
-   * String, String)}
+   *
+   * @deprecated in version 2.0.2, please use {@link Builder#createUserPasswordAuthentication(String, String, String)}
    */
   @Deprecated
   public DatabricksServiceFactory(String username, String password, String host) {
@@ -79,15 +81,13 @@ public class DatabricksServiceFactory {
   /**
    * Creating a Databricks Service object.
    *
-   * @param maxRetry http client maxRetry when failed due to I/O , timeout error
+   * @param maxRetry      http client maxRetry when failed due to I/O , timeout error
    * @param retryInterval http client retry interval when failed due to I/O , timeout error
-   *
-   * @deprecated in version 2.0.2,
-   *     please use {@link Builder#createUserPasswordAuthentication(String, String, String)}
+   * @deprecated in version 2.0.2, please use {@link Builder#createUserPasswordAuthentication(String, String, String)}
    */
   @Deprecated
   public DatabricksServiceFactory(String username, String password, String host, int maxRetry,
-      long retryInterval) {
+                                  long retryInterval) {
     this(username, password, host, maxRetry, retryInterval, false);
   }
 
@@ -96,39 +96,36 @@ public class DatabricksServiceFactory {
    * When use databricks service on CDH 5.7.1 , useLegacyAPI425 set true for v4.2.5 compatible API.
    *
    * @param useLegacyAPI425 choose what version of API compatible HttpClient.
-   * @deprecated in version 2.0.2,
-   *     please use {@link Builder#createUserPasswordAuthentication(String, String, String)}
+   * @deprecated in version 2.0.2, please use {@link Builder#createUserPasswordAuthentication(String, String, String)}
    */
   @Deprecated
   public DatabricksServiceFactory(String username, String password, String host, int maxRetry,
-      long retryInterval, boolean useLegacyAPI425) {
+                                  long retryInterval, boolean useLegacyAPI425) {
 
     client2dot0 = Builder.createUserPasswordAuthentication(username, password, host)
-          .withMaxRetries(maxRetry)
-          .withRetryInterval(retryInterval)
-          .withUseLegacyAPI425(useLegacyAPI425)
-          .build().client2dot0;
+        .withMaxRetries(maxRetry)
+        .withRetryInterval(retryInterval)
+        .withUseLegacyAPI425(useLegacyAPI425)
+        .build().client2dot0;
   }
 
   /**
    * Create a databricks service factory using personal token authentication instead.
    *
    * @param personalToken your personal token
-   * @param host the databricks host
-   * @param maxRetry the maximum number of retries
+   * @param host          the databricks host
+   * @param maxRetry      the maximum number of retries
    * @param retryInterval the retry interval between each attempt
-   *
-   * @deprecated in version 2.0.2,
-   *     please use {@link Builder#createTokenAuthentication(String, String)}
+   * @deprecated in version 2.0.2, please use {@link Builder#createTokenAuthentication(String, String)}
    */
   @Deprecated
   public DatabricksServiceFactory(String personalToken, String host,
-      int maxRetry, long retryInterval) {
+                                  int maxRetry, long retryInterval) {
 
     client2dot0 = Builder.createTokenAuthentication(personalToken, host)
-            .withMaxRetries(maxRetry)
-            .withRetryInterval(retryInterval)
-            .build().client2dot0;
+        .withMaxRetries(maxRetry)
+        .withRetryInterval(retryInterval)
+        .build().client2dot0;
   }
 
   /**
@@ -182,6 +179,16 @@ public class DatabricksServiceFactory {
   }
 
   /**
+   * Will return a Groups singleton.
+   */
+  public GroupsService getGroupsService() {
+    if (groupsService == null) {
+      groupsService = new GroupsServiceImpl(client2dot0);
+    }
+    return groupsService;
+  }
+
+  /**
    * This is how the DatabricksServiceFactory should be constructed. This gives flexibility to add
    * more parameters later without ending up with large constructors.
    */
@@ -216,7 +223,6 @@ public class DatabricksServiceFactory {
      * This could be needed in some runtime environment which provide legacy http-client library as platform runtime.
      */
     public boolean useLegacyAPI425 = false;
-
 
 
     private Builder() {
@@ -272,7 +278,7 @@ public class DatabricksServiceFactory {
      * Creates a DatabricksServiceFactory using token authentication.
      *
      * @param token your databricks token
-     * @param host the databricks host where that token is valid
+     * @param host  the databricks host where that token is valid
      * @return the builder object
      */
     public static Builder createTokenAuthentication(String token, String host) {
@@ -287,11 +293,11 @@ public class DatabricksServiceFactory {
      *
      * @param username databricks username
      * @param password databricks password
-     * @param host the host object
+     * @param host     the host object
      * @return the builder object
      */
     public static Builder createUserPasswordAuthentication(String username,
-        String password, String host) {
+                                                           String password, String host) {
       Builder builder = new Builder();
       builder.username = username;
       builder.password = password;
@@ -311,40 +317,44 @@ public class DatabricksServiceFactory {
     }
 
     /**
-    * set Http Retry Interval.
-    * @param retryInterval unit is milliseconds
-    * @return
-    */
+     * set Http Retry Interval.
+     *
+     * @param retryInterval unit is milliseconds
+     * @return
+     */
     public Builder withRetryInterval(long retryInterval) {
       this.retryInterval = retryInterval;
       return this;
     }
 
     /**
-    * set Http-Client SoTimeout.
-    * @param soTimeout unit is milliseconds
-    * @return
-    */
+     * set Http-Client SoTimeout.
+     *
+     * @param soTimeout unit is milliseconds
+     * @return
+     */
     public Builder withSoTimeout(int soTimeout) {
       this.soTimeout = soTimeout;
       return this;
     }
 
     /**
-    * set Http-Client connection timeout.
-    * @param connectionTimeout unit is milliseconds
-    * @return
-    */
+     * set Http-Client connection timeout.
+     *
+     * @param connectionTimeout unit is milliseconds
+     * @return
+     */
     public Builder withConnectionTimeout(int connectionTimeout) {
       this.connectionTimeout = connectionTimeout;
       return this;
     }
 
     /**
-    * set Http-Client connection request timeout.
-    * @param connectionRequestTimeout unit is milliseconds
-    * @return
-    */
+     * set Http-Client connection request timeout.
+     *
+     * @param connectionRequestTimeout unit is milliseconds
+     * @return
+     */
     public Builder withConnectionRequestTimeout(int connectionRequestTimeout) {
       this.connectionRequestTimeout = connectionRequestTimeout;
       return this;
@@ -358,6 +368,7 @@ public class DatabricksServiceFactory {
 
     /**
      * Builds a DatabricksServiceFactory.
+     *
      * @return the databricks service factory object
      */
     public DatabricksServiceFactory build() {

--- a/src/main/java/com/edmunds/rest/databricks/service/GroupsService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/GroupsService.java
@@ -1,0 +1,132 @@
+package com.edmunds.rest.databricks.service;
+
+import com.edmunds.rest.databricks.DTO.PrincipalNameDTO;
+import com.edmunds.rest.databricks.DatabricksRestException;
+
+import java.io.IOException;
+
+/**
+ * A wrapper around Databricks' Groups API.
+ *
+ * @see <a href="https://docs.databricks.com/api/latest/groups.html">https://docs.databricks.com/api/latest/groups.html</a>
+ */
+public interface GroupsService {
+
+  /**
+   * Adds a user to a group.
+   *
+   * @param userName   the userName to be added
+   * @param parentName name of the parent group to which the new member will be added
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#add-member">https://docs.databricks.com/api/latest/groups.html#add-member</a>
+   */
+  void addUserToGroup(String userName, String parentName) throws IOException, DatabricksRestException;
+
+  /**
+   * Adds a group to a group.
+   *
+   * @param groupName  the groupName to be added
+   * @param parentName name of the parent group to which the new member will be added
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#add-member">https://docs.databricks.com/api/latest/groups.html#add-member</a>
+   */
+  void addGroupToGroup(String groupName, String parentName) throws IOException, DatabricksRestException;
+
+  /**
+   * Creates a new group.
+   *
+   * @param groupName the groupName to be created
+   * @return the groupName
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#create">https://docs.databricks.com/api/latest/groups.html#create</a>
+   */
+  String createGroup(String groupName) throws IOException, DatabricksRestException;
+
+  /**
+   * Returns all of the members of a particular group.
+   *
+   * @param groupName the groupName whose members we want to retrieve
+   * @return all users and groups that belong to a given group
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#list-members">https://docs.databricks.com/api/latest/groups.html#list-members</a>
+   */
+  PrincipalNameDTO[] listMembers(String groupName) throws IOException, DatabricksRestException;
+
+  /**
+   * Returns all the groups in an organization.
+   *
+   * @return the groupNames of all groups
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#list">https://docs.databricks.com/api/latest/groups.html#list</a>
+   */
+  String[] listGroups() throws IOException, DatabricksRestException;
+
+  /**
+   * Retrieves all groups in which a given user is a member.
+   *
+   * @param userName name of the user
+   * @return the groupNames of all groups the user belongs to
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#list-parents">https://docs.databricks.com/api/latest/groups.html#list-parents</a>
+   */
+  String[] listParentsOfUser(String userName) throws IOException, DatabricksRestException;
+
+  /**
+   * Retrieves all groups in which a given group is a member.
+   *
+   * @param groupName name of the group
+   * @return the groupNames of all groups the group belongs to
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#list-parents">https://docs.databricks.com/api/latest/groups.html#list-parents</a>
+   */
+  String[] listParentsOfGroup(String groupName) throws IOException, DatabricksRestException;
+
+  /**
+   * Removes a user from a group.
+   *
+   * @param userName   name of the user
+   * @param parentName name of parent group
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#remove-member">https://docs.databricks.com/api/latest/groups.html#remove-member</a>
+   */
+  void removeUserFromGroup(String userName, String parentName) throws IOException, DatabricksRestException;
+
+  /**
+   * Removes a group from a group.
+   *
+   * @param groupName  name of the group
+   * @param parentName name of parent group
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#remove-member">https://docs.databricks.com/api/latest/groups.html#remove-member</a>
+   */
+  void removeGroupFromGroup(String groupName, String parentName) throws IOException, DatabricksRestException;
+
+  /**
+   * Removes a group from this organization.
+   *
+   * @param groupName name of the group to be deleted
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   * @see <a href="https://docs.databricks.com/api/latest/groups.html#delete">https://docs.databricks.com/api/latest/groups.html#delete</a>
+   */
+  void deleteGroup(String groupName) throws IOException, DatabricksRestException;
+
+  /**
+   * Check to see if a group exists with a given name.
+   *
+   * @param groupName name to check
+   * @return whether or not the groupName was found in the list of groups
+   * @throws IOException             other connection errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  boolean groupExists(String groupName) throws IOException, DatabricksRestException;
+}

--- a/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
@@ -1,0 +1,143 @@
+package com.edmunds.rest.databricks.service;
+
+import com.edmunds.rest.databricks.DTO.PrincipalNameDTO;
+import com.edmunds.rest.databricks.DatabricksRestException;
+import com.edmunds.rest.databricks.RequestMethod;
+import com.edmunds.rest.databricks.restclient.DatabricksRestClient;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.log4j.Logger;
+
+/**
+ * The implementation of GroupsService.
+ */
+public class GroupsServiceImpl extends DatabricksService implements GroupsService {
+
+  private static Logger log = Logger.getLogger(GroupsServiceImpl.class);
+
+  public GroupsServiceImpl(final DatabricksRestClient client) {
+    super(client);
+  }
+
+  @Override
+  public void addUserToGroup(String userName, String parentName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("user_name", userName);
+    data.put("parent_name", parentName);
+    client.performQuery(RequestMethod.POST, "/groups/add-member", data);
+  }
+
+  @Override
+  public void addGroupToGroup(String groupName, String parentName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("group_name", groupName);
+    data.put("parent_name", parentName);
+    client.performQuery(RequestMethod.POST, "/groups/add-member", data);
+  }
+
+  @Override
+  public String createGroup(String groupName) throws IOException, DatabricksRestException {
+    boolean groupExists = groupExists(groupName);
+    // Doing this check and logging rather than letting API throw a "RESOURCE_ALREADY_EXISTS" exception
+    if (!groupExists) {
+      Map<String, Object> data = new HashMap<>();
+      data.put("group_name", groupName);
+      byte[] responseBody = client.performQuery(RequestMethod.POST, "/groups/create", data);
+      Map<String, Object> response = this.mapper.readValue(responseBody, Map.class);
+      return (String) response.get("group_name");
+    } else {
+      log.info(String.format("Group with name [%s] already exists", groupName));
+      return groupName;
+    }
+  }
+
+  @Override
+  public PrincipalNameDTO[] listMembers(String groupName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("group_name", groupName);
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/groups/list-members", data);
+    Map<String, PrincipalNameDTO[]> jsonObject = this.mapper
+        .readValue(responseBody, new TypeReference<Map<String, PrincipalNameDTO[]>>() {
+        });
+    return jsonObject.get("members");
+  }
+
+  @Override
+  public String[] listGroups() throws IOException, DatabricksRestException {
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/groups/list", null);
+    Map<String, String[]> jsonObject = this.mapper
+        .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
+        });
+    return jsonObject.get("group_names");
+  }
+
+  @Override
+  public String[] listParentsOfUser(String userName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("user_name", userName);
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/groups/list-parents", data);
+
+    Map<String, String[]> jsonObject = this.mapper
+        .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
+        });
+    return jsonObject.get("group_names");
+  }
+
+  @Override
+  public String[] listParentsOfGroup(String groupName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("group_name", groupName);
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/groups/list-parents", data);
+
+    Map<String, String[]> jsonObject = this.mapper
+        .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
+        });
+    return jsonObject.get("group_names");
+  }
+
+  @Override
+  public void removeUserFromGroup(String userName, String parentName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("user_name", userName);
+    data.put("parent_name", parentName);
+    client.performQuery(RequestMethod.POST, "/groups/remove-member", data);
+  }
+
+  @Override
+  public void removeGroupFromGroup(String groupName, String parentName) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("group_name", groupName);
+    data.put("parent_name", parentName);
+    client.performQuery(RequestMethod.POST, "/groups/remove-member", data);
+  }
+
+  @Override
+  public void deleteGroup(String groupName) throws IOException, DatabricksRestException {
+    boolean groupExists = groupExists(groupName);
+
+    // Doing this check and logging rather than letting API throw a "RESOURCE_DOES_NOT_EXISTS" exception
+    if (groupExists) {
+      Map<String, Object> data = new HashMap<>();
+      data.put("group_name", groupName);
+      client.performQuery(RequestMethod.POST, "/groups/delete", data);
+    } else {
+      log.info(String.format("Group with name [%s] does not exist", groupName));
+    }
+  }
+
+  @Override
+  public boolean groupExists(String groupName) throws IOException, DatabricksRestException {
+    String[] groups = listGroups();
+    if (groups.length == 0) {
+      return false;
+    }
+    for (String group : groups) {
+      if (group.equals(groupName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
@@ -48,7 +48,14 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
       data.put("group_name", groupName);
       byte[] responseBody = client.performQuery(RequestMethod.POST, "/groups/create", data);
       Map<String, Object> response = this.mapper.readValue(responseBody, Map.class);
-      return (String) response.get("group_name");
+      Object returnedGroupName = response.get("group_name");
+      if (returnedGroupName != null) {
+        return (String) returnedGroupName;
+      } else {
+        throw new DatabricksRestException(String.format("There was an issue creating group [%s]. "
+            + "No group_name was returned. You may need to reach out to Databricks Support for further diagnosis.",
+            groupName));
+      }
     } else {
       log.info(String.format("Group with name [%s] already exists", groupName));
       return groupName;

--- a/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
@@ -122,7 +122,6 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
   @Override
   public void deleteGroup(String groupName) throws IOException, DatabricksRestException {
     boolean groupExists = groupExists(groupName);
-
     // Doing this check and logging rather than letting API throw a "RESOURCE_DOES_NOT_EXISTS" exception
     if (groupExists) {
       Map<String, Object> data = new HashMap<>();

--- a/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/GroupsServiceImpl.java
@@ -16,6 +16,8 @@ import org.apache.log4j.Logger;
 public class GroupsServiceImpl extends DatabricksService implements GroupsService {
 
   private static Logger log = Logger.getLogger(GroupsServiceImpl.class);
+  private static final PrincipalNameDTO[] EMPTY_MEMBERS_ARRAY = {};
+  private static final String[] EMPTY_STRING_ARRAY = {};
 
   public GroupsServiceImpl(final DatabricksRestClient client) {
     super(client);
@@ -61,7 +63,8 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
     Map<String, PrincipalNameDTO[]> jsonObject = this.mapper
         .readValue(responseBody, new TypeReference<Map<String, PrincipalNameDTO[]>>() {
         });
-    return jsonObject.get("members");
+    PrincipalNameDTO[] members = jsonObject.get("members");
+    return members != null ? members : EMPTY_MEMBERS_ARRAY;
   }
 
   @Override
@@ -70,7 +73,8 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
     Map<String, String[]> jsonObject = this.mapper
         .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
         });
-    return jsonObject.get("group_names");
+    String[] groups = jsonObject.get("group_names");
+    return groups != null ? groups : EMPTY_STRING_ARRAY;
   }
 
   @Override
@@ -82,7 +86,8 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
     Map<String, String[]> jsonObject = this.mapper
         .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
         });
-    return jsonObject.get("group_names");
+    String[] groups = jsonObject.get("group_names");
+    return groups != null ? groups : EMPTY_STRING_ARRAY;
   }
 
   @Override
@@ -94,7 +99,8 @@ public class GroupsServiceImpl extends DatabricksService implements GroupsServic
     Map<String, String[]> jsonObject = this.mapper
         .readValue(responseBody, new TypeReference<Map<String, String[]>>() {
         });
-    return jsonObject.get("group_names");
+    String[] groups = jsonObject.get("group_names");
+    return groups != null ? groups : EMPTY_STRING_ARRAY;
   }
 
   @Override

--- a/src/test/java/com/edmunds/rest/databricks/service/GroupsServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/GroupsServiceTest.java
@@ -1,0 +1,158 @@
+package com.edmunds.rest.databricks.service;
+
+import com.edmunds.rest.databricks.DTO.PrincipalNameDTO;
+import com.edmunds.rest.databricks.DatabricksRestException;
+import com.edmunds.rest.databricks.DatabricksServiceFactory;
+import com.edmunds.rest.databricks.fixtures.DatabricksFixtures;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unfortunately, we currently do not have a way of testing adding/removing Users to groups(as opposed to
+ * adding/removing a group to a group) because databricks API does not support creation of users.
+ */
+public class GroupsServiceTest {
+
+  private GroupsService service;
+  private final String testGroupName = "dbRestClientTestGroup";
+  private final String testGroupName2 = "dbRestClientTestGroup2";
+  private final String testUser = "testUsers";
+
+  @BeforeClass
+  public void setUpOnce() throws IOException, DatabricksRestException {
+    DatabricksServiceFactory factory = DatabricksFixtures.getDatabricksServiceFactory();
+
+    service = factory.getGroupsService();
+
+    // Delete test groups if exists
+    deleteAllTestGroups();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void finalCleanUp() throws IOException, DatabricksRestException {
+    deleteAllTestGroups();
+  }
+
+  @AfterMethod
+  public void tearDown() throws IOException, DatabricksRestException {
+    deleteAllTestGroups();
+  }
+
+  @Test
+  public void createGroup_whenCalled_createsGroupWithCorrectName() throws IOException, DatabricksRestException {
+    String returnedName = service.createGroup(testGroupName);
+    assertEquals(returnedName, testGroupName);
+  }
+
+  @Test(dependsOnMethods = {"createGroup_whenCalled_createsGroupWithCorrectName"})
+  public void groupExists_whenCalledWithExistingGroup_returnsTrue() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    assertTrue(service.groupExists(testGroupName));
+  }
+
+  @Test(dependsOnMethods = {"createGroup_whenCalled_createsGroupWithCorrectName"})
+  public void groupExists_whenCalledWithNonExistingGroup_returnsFalse() throws IOException, DatabricksRestException {
+    assertFalse(service.groupExists(testGroupName));
+  }
+
+  @Test(dependsOnMethods = {"groupExists_whenCalledWithNonExistingGroup_returnsFalse"})
+  public void deleteGroup_whenCalled_correctlyDeletesGroup() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.deleteGroup(testGroupName);
+    assertFalse(service.groupExists(testGroupName));
+  }
+
+  @Test(dependsOnMethods = {"createGroup_whenCalled_createsGroupWithCorrectName"})
+  public void addGroupToGroup_whenCalled_correctlyAddsUserToGroup() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.createGroup(testUser);
+
+    service.addGroupToGroup(testUser, testGroupName);
+    assertTrue(groupBelongsToGroup(testUser, testGroupName));
+  }
+
+  @Test(dependsOnMethods = {"createGroup_whenCalled_createsGroupWithCorrectName"})
+  public void listGroups_whenCalled_returnsNonZeroArray() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+
+    String[] groups = service.listGroups();
+    assertTrue(groups.length > 0);
+  }
+
+  @Test(dependsOnMethods = {"addGroupToGroup_whenCalled_correctlyAddsUserToGroup"})
+  public void listMembers_whenCalledWithNonEmptyGroup_returnsAllMembers()
+      throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.createGroup(testUser);
+    service.addGroupToGroup(testUser, testGroupName);
+
+    PrincipalNameDTO[] members = service.listMembers(testGroupName);
+    assertEquals(members.length, 1);
+  }
+
+  @Test(dependsOnMethods = {"addGroupToGroup_whenCalled_correctlyAddsUserToGroup"})
+  public void listParentsOfGroup_whenCalled_returnsCorrectParent() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.createGroup(testUser);
+    service.addGroupToGroup(testUser, testGroupName);
+
+    String[] parents = service.listParentsOfGroup(testUser);
+    assertEquals(parents.length, 1);
+    assertEquals(parents[0], testGroupName);
+  }
+
+  @Test(dependsOnMethods = {"addGroupToGroup_whenCalled_correctlyAddsUserToGroup"})
+  public void listParentsOfGroup_whenCalledWithMultipleParents_returnsCorrectParent()
+      throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.createGroup(testGroupName2);
+    service.createGroup(testUser);
+    service.addGroupToGroup(testUser, testGroupName);
+    service.addGroupToGroup(testUser, testGroupName2);
+
+    String[] parents = service.listParentsOfGroup(testUser);
+    assertEquals(parents.length, 2);
+  }
+
+  @Test(dependsOnMethods = {"addGroupToGroup_whenCalled_correctlyAddsUserToGroup"})
+  public void removeUserFromGroup_whenCalled_removesUser() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+    service.createGroup(testUser);
+    service.addGroupToGroup(testUser, testGroupName);
+
+    service.removeGroupFromGroup(testUser, testGroupName);
+
+    assertFalse(groupBelongsToGroup(testUser, testGroupName));
+  }
+
+  private void deleteTestGroup(String group) throws IOException, DatabricksRestException {
+    service.deleteGroup(group);
+  }
+
+  private void deleteAllTestGroups() throws IOException, DatabricksRestException {
+    deleteTestGroup(testGroupName);
+    deleteTestGroup(testGroupName2);
+    deleteTestGroup(testUser);
+  }
+
+  private boolean groupBelongsToGroup(String userName, String groupName) throws IOException, DatabricksRestException {
+    PrincipalNameDTO[] members = service.listMembers(groupName);
+    if (members == null) {
+      return false;
+    }
+    if (members.length == 0) {
+      return false;
+    }
+    for (PrincipalNameDTO member : members) {
+      if (member.getGroupName() != null && member.getGroupName().equals(userName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/com/edmunds/rest/databricks/service/GroupsServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/GroupsServiceTest.java
@@ -95,6 +95,14 @@ public class GroupsServiceTest {
     assertEquals(members.length, 1);
   }
 
+  @Test(dependsOnMethods = {"createGroup_whenCalled_createsGroupWithCorrectName"})
+  public void listParentsOfGroup_whenCalledWithNoParents_returnsEmptyArray() throws IOException, DatabricksRestException {
+    service.createGroup(testGroupName);
+
+    String[] parents = service.listParentsOfGroup(testGroupName);
+    assertEquals(parents.length, 0);
+  }
+
   @Test(dependsOnMethods = {"addGroupToGroup_whenCalled_correctlyAddsUserToGroup"})
   public void listParentsOfGroup_whenCalled_returnsCorrectParent() throws IOException, DatabricksRestException {
     service.createGroup(testGroupName);


### PR DESCRIPTION
Couple of points to note:

1) databricks API accepts user_name or group_name for several of its methods to determine what to do, so I split these options up into separate methods, e.g. addUserToGroup vs. addGroupToGroup

2) I opted to do logging + no-op for some of the delete-related commands rather than letting databricks throw an exception as this seems like more intuitive behavior to me. but open to changing that. 

3) I opted to return empty arrays rather than nulls where applicable.