### PR TITLE
Add the cluster api missing methods - related to to issue 34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>2.6.3-SNAPSHOT</version>
+    <version>2.6.4-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/DTO/NodeTypesDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/NodeTypesDTO.java
@@ -13,25 +13,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+package com.edmunds.rest.databricks.DTO;
 
-package com.edmunds.rest.databricks.DTO.clusters;
-
+import com.edmunds.rest.databricks.DTO.clusters.NodeTypeDTO;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
 import java.util.List;
 import lombok.Data;
 
-/**
- *
- */
 @Data
-public class ClusterCloudProviderNodeInfoDTO implements Serializable {
-  //note - the current documentation (MAY-05-2020) shows a string here, however the API returns an JSON array
-  @JsonProperty("status")
-  private List<ClusterCloudProviderNodeStatusDTO> statuses;
-  @JsonProperty("available_core_quota")
-  private int availableCoreQuota;
-  @JsonProperty("total_core_quota")
-  private int totalCoreQuota;
-
+public class NodeTypesDTO {
+  @JsonProperty("node_types")
+  private List<NodeTypeDTO> nodeTypes;
 }

--- a/src/main/java/com/edmunds/rest/databricks/DTO/SparkVersionsDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/SparkVersionsDTO.java
@@ -13,25 +13,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+package com.edmunds.rest.databricks.DTO;
 
-package com.edmunds.rest.databricks.DTO.clusters;
-
+import com.edmunds.rest.databricks.DTO.clusters.SparkVersionDTO;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
-import java.util.List;
 import lombok.Data;
 
-/**
- *
- */
 @Data
-public class ClusterCloudProviderNodeInfoDTO implements Serializable {
-  //note - the current documentation (MAY-05-2020) shows a string here, however the API returns an JSON array
-  @JsonProperty("status")
-  private List<ClusterCloudProviderNodeStatusDTO> statuses;
-  @JsonProperty("available_core_quota")
-  private int availableCoreQuota;
-  @JsonProperty("total_core_quota")
-  private int totalCoreQuota;
+public class SparkVersionsDTO {
 
+  @JsonProperty("versions")
+  private SparkVersionDTO[] sparkVersions;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -21,6 +21,8 @@ import com.edmunds.rest.databricks.DTO.clusters.AutoScaleDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterInfoDTO;
+import com.edmunds.rest.databricks.DTO.clusters.NodeTypeDTO;
+import com.edmunds.rest.databricks.DTO.clusters.SparkVersionDTO;
 import com.edmunds.rest.databricks.DTO.jobs.NewClusterDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
@@ -135,6 +137,15 @@ public interface ClusterService {
   void delete(String clusterId) throws IOException, DatabricksRestException;
 
   /**
+   * Permanently terminates a cluster.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#permanent-delete">https://docs.databricks.com/api/latest/clusters.html#permanent-delete</a>
+   * @param clusterId the cluster you want to permanently terminate
+   * @throws IOException any other errors
+   * @throws DatabricksRestException errors with request
+   */
+  void permanentDelete(String clusterId) throws IOException, DatabricksRestException;
+
+  /**
    * Gets information about a given cluster.
    * @see <a href="https://docs.databricks.com/api/latest/clusters.html#get">https://docs.databricks.com/api/latest/clusters.html#get</a>
    * @param clusterId the cluster you want to get info about
@@ -200,4 +211,51 @@ public interface ClusterService {
    */
   Optional<ClusterInfoDTO> findUniqueByName(String clusterName)
       throws IOException, DatabricksRestException;
+
+  /**
+   * Pin a cluster with a given id. Needs administrator rights.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#pin">https://docs.databricks.com/api/latest/clusters.html#pin</a>
+   * @param clusterId the clusterId you want to pin
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  void pin(String clusterId) throws IOException, DatabricksRestException;
+
+  /**
+   * Unpin a cluster with a given id. Needs administrator rights.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#unpin">https://docs.databricks.com/api/latest/clusters.html#unpin</a>
+   * @param clusterId the clusterId you want to unpin
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  void unpin(String clusterId) throws IOException, DatabricksRestException;
+
+  /**
+   * Return a list of supported Spark node types.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#list-node-types">https://docs.databricks.com/api/latest/clusters.html#list-node-types</a>
+   * @return an array of node types
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  List<NodeTypeDTO> listNodeTypes() throws IOException, DatabricksRestException;
+
+  /**
+   * Return a list of availability zones where clusters can be created in. This method only works on AWS.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#list-zones">https://docs.databricks.com/api/latest/clusters.html#list-zones</a>
+   * @return the a list of availability zones
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  List<String> listZones() throws IOException, DatabricksRestException;
+
+  /**
+   * Return the list of available runtime versions.
+   * @see <a href="https://docs.databricks.com/api/latest/clusters.html#spark-versions">https://docs.databricks.com/api/latest/clusters.html#spark-versions</a>
+   * @return the a list of runtime versions
+   * @throws IOException any other errors
+   * @throws DatabricksRestException any errors with the request
+   */
+  List<SparkVersionDTO> listSparkVersions() throws IOException, DatabricksRestException;
+
+
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -17,12 +17,16 @@
 package com.edmunds.rest.databricks.service;
 
 import com.edmunds.rest.databricks.DTO.ClusterEventsDTO;
+import com.edmunds.rest.databricks.DTO.NodeTypesDTO;
+import com.edmunds.rest.databricks.DTO.SparkVersionsDTO;
 import com.edmunds.rest.databricks.DTO.UpsertClusterDTO;
 import com.edmunds.rest.databricks.DTO.clusters.AutoScaleDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterStateDTO;
+import com.edmunds.rest.databricks.DTO.clusters.NodeTypeDTO;
+import com.edmunds.rest.databricks.DTO.clusters.SparkVersionDTO;
 import com.edmunds.rest.databricks.DTO.jobs.NewClusterDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.RequestMethod;
@@ -32,6 +36,7 @@ import com.edmunds.rest.databricks.restclient.DatabricksRestClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +137,13 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
   }
 
   @Override
+  public void permanentDelete(String clusterId) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("cluster_id", clusterId);
+    client.performQuery(RequestMethod.POST, "/clusters/permanent-delete", data);
+  }
+
+  @Override
   public ClusterInfoDTO getInfo(String clusterId) throws IOException, DatabricksRestException {
     Map<String, Object> data = new HashMap<>();
     data.put("cluster_id", clusterId);
@@ -210,4 +222,38 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
       return Optional.empty();
     }
   }
+
+  @Override
+  public void pin(String clusterId) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("cluster_id", clusterId);
+    client.performQuery(RequestMethod.POST, "/clusters/pin", data);
+  }
+
+  @Override
+  public void unpin(String clusterId) throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("cluster_id", clusterId);
+    client.performQuery(RequestMethod.POST, "/clusters/unpin", data);
+  }
+
+  @Override
+  public List<NodeTypeDTO> listNodeTypes() throws IOException, DatabricksRestException {
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/clusters/list-node-types");
+    return mapper.readValue(responseBody, NodeTypesDTO.class).getNodeTypes();
+  }
+
+  @Override
+  public List<String> listZones() throws IOException, DatabricksRestException {
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/clusters/list-zones");
+    return mapper.readValue(responseBody, new TypeReference<List<String>>() {
+    });
+  }
+
+  @Override
+  public List<SparkVersionDTO> listSparkVersions() throws IOException, DatabricksRestException {
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/clusters/spark-versions");
+    return Arrays.asList(mapper.readValue(responseBody, SparkVersionsDTO.class).getSparkVersions());
+  }
+
 }


### PR DESCRIPTION
https://github.com/edmunds/databricks-rest-client/issues/34

add the cluster api missing methods
new DTOs + changed DTOs accordingly
bump pom.xml version

Note: I can't run the cluster integration tests as they only work on AWS - and I only have Azure accounts. Ideally the tests should be changed to work on both environments - not a huge amount of work  but it's outside of this PR scope.

How should we proceed? Should I write some tests and somebody will test them on AWS? (on the other hand the methods are quite straightforward, I don't believe that testing them is mandatory.